### PR TITLE
fix() problema com caracter especial usando toString não estava trata…

### DIFF
--- a/src/Horse.Jhonson.pas
+++ b/src/Horse.Jhonson.pas
@@ -65,7 +65,7 @@ begin
       {$IF DEFINED(FPC)}
       Res.RawWebResponse.ContentStream := TStringStream.Create(TJsonData(Res.Content).AsJSON);
       {$ELSE}
-      Res.RawWebResponse.Content := TJSONValue(Res.Content).ToString;
+      Res.RawWebResponse.Content := TJSONValue(Res.Content).ToJSON;
       {$ENDIF}
       Res.RawWebResponse.ContentType := 'application/json; charset=' + Charset;
     end;


### PR DESCRIPTION
…ndo retorno invalidando json em alguns casos.


funcionava antes deste commit https://github.com/HashLoad/jhonson/commit/80fb6d0334298af8245ebdcc3b5ed16dd361adb7